### PR TITLE
Removed Globally Leaked tmpl function

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -20,7 +20,8 @@
  *   jquery.js
  */
 (function ($) {
-  var DatePicker = function () {
+  var cache = {}, tmpl,
+  DatePicker = function () {
     var ids = {},
       views = {
         years: 'datepickerViewYears',
@@ -977,13 +978,8 @@
     DatePickerClear: DatePicker.clear,
     DatePickerLayout: DatePicker.fixLayout
   });
-})(jQuery);
 
-(function(){
-  // within here, 'this' refers to the window object
-  var cache = {};
-  
-  this.tmpl = function tmpl(str, data){
+  tmpl = function tmpl(str, data){
     // Figure out if we're getting a template, or if we need to
     // load the template - and be sure to cache the result.
     var fn = !/\W/.test(str) ?
@@ -1012,4 +1008,5 @@
     // Provide some basic currying to the user
     return data ? fn( data ) : fn;
   };
-})();
+
+})(jQuery);


### PR DESCRIPTION
I moved the tmpl function used into the DatePicker scope. tmpl is a common name and this was clashing with another library that was in use on my project. 
Moving tmpl into the DatePicker scope allows you to use your version of tmpl in DatePicker.js yet keep another version outside of DatePicker.js - as templating isn't the primary function of your library.
