### PR TITLE
Selectable Date Range Configuration

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -149,6 +149,12 @@
          */
         current: null,
         /**
+         * Optional date range which limits the selectable dates. The range of acceptable dates,
+         * in an array of [min, max], disables any date outside of the range. Arguments should be
+         * Date objects.
+         */
+        selectableDates: null,
+        /**
          * true causes the datepicker calendar to be appended to the DatePicker 
          * element and rendered, false binds the DatePicker to an event on the trigger element
          */
@@ -333,11 +339,15 @@
             if (today.getDate() == date.getDate() && today.getMonth() == date.getMonth() && today.getYear() == date.getYear()) {
               data.weeks[indic].days[indic2].classname.push('datepickerToday');
             }
-            if (date > today) {
+            if($.isArray(options.selectableDates) && options.selectableDates.length == 2) {
+              if(date < options.selectableDates[0] || date > options.selectableDates[1]) {
+                data.weeks[indic].days[indic2].classname.push('datepickerFuture');
+                data.weeks[indic].days[indic2].classname.push('datepickerDisabled');
+              }
+            } else if (date > today) {
               // current month, date in future
               data.weeks[indic].days[indic2].classname.push('datepickerFuture');
             }
-            
             if (month != date.getMonth()) {
               data.weeks[indic].days[indic2].classname.push('datepickerNotInMonth');
               // disable clicking of the 'not in month' cells


### PR DESCRIPTION
Adding date range configuration. This setting overrides the default of disabling all future dates, and instead allows the user to configure an array of [start,end] dates to limit the selectable dates.
