### PR TITLE
Remove use of the deprecated $.curCSS

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -688,7 +688,7 @@
           var viewPort = getViewport();
           var top = pos.top;
           var left = pos.left;
-          var oldDisplay = $.curCSS(calEl, 'display');
+          var oldDisplay = $.css(calEl, 'display');
           cal.css({
             visibility: 'hidden',
             display: 'block'


### PR DESCRIPTION
$.curCSS was dropped in 1.8 - since 1.3 curCSS has just been an alias for $.css, so it is safe to just replace curCSS with css:

http://blog.jquery.com/2012/08/09/jquery-1-8-released/
