### PR TITLE
moths changed to months

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -25,7 +25,7 @@
     var ids = {},
       views = {
         years: 'datepickerViewYears',
-        moths: 'datepickerViewMonths',
+        months: 'datepickerViewMonths',
         days:  'datepickerViewDays'
       },
       tpl = {


### PR DESCRIPTION
Misspelling of the word 'months'