### PR TITLE
reset lastSel flag when setDate or clear is called

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -917,6 +917,7 @@
           if ($(this).data('datepickerId')) {
             var cal = $('#' + $(this).data('datepickerId'));
             var options = cal.data('datepicker');
+            options.lastSel = false;
             options.date = normalizeDate(options.mode, date);
             
             if (shiftTo) {
@@ -959,6 +960,7 @@
             } else {
               options.date = [];
             }
+            options.lastSel = false;
             fill(cal.get(0));
           }
         });


### PR DESCRIPTION
I fixed `lastSel` flag to be reset when `setDate` or `clear` flag is called in case DatePicker is initialized with range mode.
Unless this fix, first date selection persists when date range is set externally or cleared.